### PR TITLE
Add printing stack-trace to console when redis couldn't connect.

### DIFF
--- a/velocity/src/main/java/io/alerium/chocolate/ChocolatePlugin.java
+++ b/velocity/src/main/java/io/alerium/chocolate/ChocolatePlugin.java
@@ -102,4 +102,8 @@ public class ChocolatePlugin {
         this.server.getConsoleCommandSource().sendMessage(LegacyComponentSerializer.legacySection().deserialize(StringUtils.getInstance()
                 .colorize(msg)));
     }
+
+    public void logToConsole(String msg, Exception ex) {
+        this.logger.error(msg, ex);
+    }
 }

--- a/velocity/src/main/java/io/alerium/chocolate/redis/RedisManager.java
+++ b/velocity/src/main/java/io/alerium/chocolate/redis/RedisManager.java
@@ -36,7 +36,7 @@ public class RedisManager {
             proxyId = chocolatePlugin.getConfig().getString("proxyName", "proxy1");
             return true;
         } catch (Exception ex) {
-            chocolatePlugin.logToConsole("&4Couldn't initialize redis connection.");
+            chocolatePlugin.logToConsole("&4Couldn't initialize redis connection.",ex);
             chocolatePlugin.getServer().shutdown();
             return false;
         }


### PR DESCRIPTION
This PR adds a stack trace to be printed when there is an exception whilst connecting to the Redis server. This allows server-owners to find issues with their Redis configuration or server easier.