### PR TITLE
Fix NullPointerException when the SyncManager instance is created

### DIFF
--- a/velocity/src/main/java/io/alerium/chocolate/ChocolatePlugin.java
+++ b/velocity/src/main/java/io/alerium/chocolate/ChocolatePlugin.java
@@ -96,6 +96,7 @@ public class ChocolatePlugin {
     private void loadInstances() {
         this.syncManager = new SyncManager(this.redisManager.getRedissonClient(), this);
         this.cacheManager = new CacheManager(this.syncManager);
+        this.syncManager.cleanPlayers();
     }
 
     public void logToConsole(String msg) {

--- a/velocity/src/main/java/io/alerium/chocolate/network/SyncManager.java
+++ b/velocity/src/main/java/io/alerium/chocolate/network/SyncManager.java
@@ -39,11 +39,12 @@ public class SyncManager {
             return thread;
         });
 
-        Iterator<UUID> iterator = getOnlinePlayersInProxy(this.proxyId).iterator();
-        while (iterator.hasNext()) cleanPlayer(iterator.next());
-
         this.executorService.scheduleAtFixedRate(this::runSyncTask, 1, 1, TimeUnit.SECONDS);
         this.chocolatePlugin.getServer().getEventManager().register(chocolatePlugin, new PlayerListener(chocolatePlugin));
+    }
+
+    public void cleanPlayers(){
+        for (UUID uuid : getOnlinePlayersInProxy(this.proxyId)) cleanPlayer(uuid);
     }
 
     private void runSyncTask() {


### PR DESCRIPTION
This PR fixes a NullPointerException caused by the <init> of the SyncManager using the CacheManager before the CacheManager is initialized. This is the stack trace printed when the issue occurred https://pastebin.com/QcGfzxvC, this is resolved in this PR.